### PR TITLE
kyrylo/support-for-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ itertools = "0.10"
 near-primitives-core = "0.15"
 near-units = "0.2"
 near-vm-errors = "3.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 serde = { version = "1", default-features = false, features = ["derive", "rc"] }
 serde_json = { version = "1", default-features = false }
 thiserror = "1"

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -138,8 +138,8 @@ mod tests {
         };
 
         assert_eq!(
-            serde_json::to_value(&resp).unwrap(),
-            serde_json::to_value(&serde_json::json!({
+            serde_json::to_value(resp).unwrap(),
+            serde_json::to_value(serde_json::json!({
                 "id": "dontcare",
                 "jsonrpc": "2.0",
                 "result": "some value",


### PR DESCRIPTION
added rustls instead of system-defined libssl to simplify cross-compiling